### PR TITLE
Handle phars in tools as binary

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+tools/* binary


### PR DESCRIPTION
This increases performance of git through managing the phars in `tools` as binaries.